### PR TITLE
fix: Escape MySQL entity names with back-ticks

### DIFF
--- a/anonymize.py
+++ b/anonymize.py
@@ -14,7 +14,7 @@ def get_truncates(config):
     truncates = database.get('truncate', [])
     sql = []
     for truncate in truncates:
-        sql.append('TRUNCATE %s' % truncate)
+        sql.append('TRUNCATE `%s`' % truncate)
     return sql
 
 
@@ -26,8 +26,8 @@ def get_deletes(config):
         if 'delete' in data:
             fields = []
             for f, v in data['delete'].iteritems():
-                fields.append('%s = "%s"' % (f, v))
-            statement = 'DELETE FROM %s WHERE ' % table + ' AND '.join(fields)
+                fields.append('`%s` = "%s"' % (f, v))
+            statement = 'DELETE FROM `%s` WHERE ' % table + ' AND '.join(fields)
             sql.append(statement)
     return sql
 
@@ -44,45 +44,45 @@ def get_updates(config):
         for operation, details in data.iteritems():
             if operation == 'nullify':
                 for field in listify(details):
-                    updates.append("%s = NULL" % field)
+                    updates.append("`%s` = NULL" % field)
             elif operation == 'random_int':
                 for field in listify(details):
-                    updates.append("%s = ROUND(RAND()*1000000)" % field)
+                    updates.append("`%s` = ROUND(RAND()*1000000)" % field)
             elif operation == 'random_ip':
                 for field in listify(details):
-                    updates.append("%s = INET_NTOA(RAND()*1000000000)" % field)
+                    updates.append("`%s` = INET_NTOA(RAND()*1000000000)" % field)
             elif operation == 'random_email':
                 for field in listify(details):
-                    updates.append("%s = CONCAT(id, '@mozilla.com')"
+                    updates.append("`%s` = CONCAT(id, '@mozilla.com')"
                                    % field)
             elif operation == 'random_username':
                 for field in listify(details):
-                    updates.append("%s = CONCAT('_user_', id)" % field)
+                    updates.append("`%s` = CONCAT('_user_', id)" % field)
             elif operation == 'hash_value':
                 for field in listify(details):
-                    updates.append("%(field)s = MD5(CONCAT(@common_hash_secret, %(field)s))"
+                    updates.append("`%(field)s` = MD5(CONCAT(@common_hash_secret, `%(field)s`))"
                                    % dict(field=field))
             elif operation == 'hash_email':
                 for field in listify(details):
-                    updates.append("%(field)s = CONCAT(MD5(CONCAT(@common_hash_secret, %(field)s)), '@mozilla.com')"
+                    updates.append("`%(field)s` = CONCAT(MD5(CONCAT(@common_hash_secret, `%(field)s`)), '@mozilla.com')"
                                    % dict(field=field))
             elif operation == 'delete':
                 continue
             else:
                 log.warning('Unknown operation.')
         if updates:
-            sql.append('UPDATE %s SET %s' % (table, ', '.join(updates)))
+            sql.append('UPDATE `%s` SET %s' % (table, ', '.join(updates)))
     return sql
 
 
 def anonymize(config):
     database = config.get('database', {})
-    
+
     if 'name' in database:
-         print "USE %s;" % database['name']
+         print "USE `%s`;" % database['name']
 
     print "SET FOREIGN_KEY_CHECKS=0;"
-    
+
     sql = []
     sql.extend(get_truncates(config))
     sql.extend(get_deletes(config))
@@ -94,7 +94,7 @@ def anonymize(config):
     print
 
 if __name__ == '__main__':
-    
+
     import yaml
     import sys
 
@@ -115,5 +115,5 @@ if __name__ == '__main__':
         else:
             databases = cfg.get('databases')
             for name, sub_cfg in databases.items():
-                print "USE %s;" % name
+                print "USE `%s`;" % name
                 anonymize({'database': sub_cfg})


### PR DESCRIPTION
Resolves an issue where running this script, on less fortunate table, column names which contain characters such as `.`, would result in SQL statements that fail due to lack of escaping. Back ticks should reduce ambiguity in generated SQL statements.
